### PR TITLE
feat: blacklists

### DIFF
--- a/src/default.rs
+++ b/src/default.rs
@@ -4,6 +4,53 @@ use std::collections::HashMap;
 
 lazy_static! {
 
+    /// The default Blacklist of regular expressions used to check for non-informative words
+    /// in the description to be excluded from scoring. If ANY of these expression matches
+    /// the word is considered as non-informative
+    pub static ref BLACKLIST_DESCRIPTION_WORDS_REGEXS: Vec<Regex> = vec![
+        Regex::new(r"(?i)\bunknown\b").unwrap(),
+        Regex::new(r"(?i)\bmember\b").unwrap(),
+        Regex::new(r"(?i)\blike\b").unwrap(),
+        Regex::new(r"(?i)\bassociated\b").unwrap(),
+        Regex::new(r"(?i)\bcontaining\b").unwrap(),
+        Regex::new(r"(?i)\bactivated\b").unwrap(),
+        Regex::new(r"(?i)\bfamily\b").unwrap(),
+        Regex::new(r"(?i)\bsubfamily\b").unwrap(),
+        Regex::new(r"(?i)\binteracting\b").unwrap(),
+        Regex::new(r"(?i)\bactivity\b").unwrap(),
+        Regex::new(r"(?i)\bsimilar\b").unwrap(),
+        Regex::new(r"(?i)\bproduct\b").unwrap(),
+        Regex::new(r"(?i)\bexpressed\b").unwrap(),
+        Regex::new(r"(?i)\bpredicted\b").unwrap(),
+        Regex::new(r"(?i)\bputative\b").unwrap(),
+        Regex::new(r"(?i)\buncharacterized\b").unwrap(),
+        Regex::new(r"(?i)\bprobable\b").unwrap(),
+        Regex::new(r"(?i)\bprotein\b").unwrap(),
+        Regex::new(r"(?i)\bgene\b").unwrap(),
+        Regex::new(r"(?i)\btair\b").unwrap(),
+        Regex::new(r"(?i)\bfragment\b").unwrap(),
+        Regex::new(r"(?i)\bhomolog\b").unwrap(),
+        Regex::new(r"(?i)\bcontig\b").unwrap(),
+        Regex::new(r"(?i)\brelated\b").unwrap(),
+        Regex::new(r"(?i)\bremark\b").unwrap(),
+        Regex::new(r"(?i)\b\w?orf(\w?|\d+)\b").unwrap(),
+    ];
+
+    /// The default Blacklist of regular expressions used to filter out Hit title (`stitle`) fields
+    /// if they match ANY of these expressions. 
+    pub static ref BLACKLIST_STITLE_REGEXS: Vec<Regex> = vec![
+        Regex::new(r"(?i)^similar\s+to").unwrap(),
+        Regex::new(r"(?i)^probable ").unwrap(),
+        Regex::new(r"(?i)^putative ").unwrap(),
+        Regex::new(r"(?i)^predicted ").unwrap(),
+        Regex::new(r"(?i)^uncharacterized").unwrap(),
+        Regex::new(r"(?i)^unknown").unwrap(),
+        Regex::new(r"(?i)^hypothetical").unwrap(),
+        Regex::new(r"(?i)^unnamed").unwrap(),
+        Regex::new(r"(?i)^whole\s+genome\s+shotgun\s+sequence").unwrap(),
+        Regex::new(r"(?i)^clone").unwrap(),
+    ];
+
     /// The default regular expressions used to filter a Hit title (`stitle`) and retain the short
     /// human readable description.
     pub static ref FILTER_REGEXS: Vec<Regex> = vec![

--- a/src/model_funcs.rs
+++ b/src/model_funcs.rs
@@ -1,6 +1,21 @@
 use eq_float::F64;
 use regex::Regex;
 
+/// Applies a list of regular expressions to a string. If any of them match returns true,
+/// otherwise returns false.
+/// This function is used to exclude non-informative descriptions from a human readable
+/// sequence title and to check for non-informative words to be excluded from scoring
+/// 
+/// # Arguments
+/// 
+/// * stitle - The sequence title string
+/// * regexs - A vector of regular expression to be applied to the stitle argument.
+pub fn matches_blacklist(stitle: &str, regexs: &Vec<Regex>) -> bool {
+    regexs
+        .iter()
+        .any(|x| x.is_match(&stitle.to_string()))
+}
+
 /// Fasta entries have a long title in which the sequence identifier and often taxonomic
 /// information is given along with a short human readable protein description. We are only
 /// interested in the latter. This function extracts the short description using regular
@@ -59,5 +74,27 @@ mod tests {
             filter_stitle(t1, &(*FILTER_REGEXS)),
             "Probable LRR receptor-like serine/threonine-protein kinase At3g47570"
         );
+    }
+
+    #[test]
+    fn default_matches_blacklist_regexs(){
+        let t1 = "LRR receptor-like serine/threonine-protein kinase EFR";
+        assert_eq!(false,matches_blacklist(t1, &(*BLACKLIST_STITLE_REGEXS)));
+
+        let t2 = "Probable LRR receptor-like serine/threonine-protein kinase At3g47570";
+        assert_eq!(true,matches_blacklist(t2, &(*BLACKLIST_STITLE_REGEXS)));
+        
+        let t3 = "Putative receptor-like protein kinase At3g47110";
+        assert_eq!(true,matches_blacklist(t3, &(*BLACKLIST_STITLE_REGEXS)));
+
+        let t4 = "hypothetical receptor-like protein kinase At3g47110";
+        assert_eq!(true,matches_blacklist(t4, &(*BLACKLIST_STITLE_REGEXS)));
+
+        let t5 = "whole Genome shotgun Sequence";
+        assert_eq!(true,matches_blacklist(t5, &(*BLACKLIST_STITLE_REGEXS)));
+
+        let t6 = "predicted Receptor-like protein kinase";
+        assert_eq!(true,matches_blacklist(t6, &(*BLACKLIST_STITLE_REGEXS)));
+
     }
 }


### PR DESCRIPTION
## Description

This PR implements the defaults and method needed to blacklist certain non-informative descriptions from the human readable description of the `stitle` strings and to exclude non-informative words from scoring after splitting the descriptions into words.

Regex patterns are taken from [AHRD](https://github.com/asishallab/AHRD)

## Changelog
- add `match_blacklist` function that applies a list of regular expressions to a string
- add default blacklists