### PR TITLE
Improve error messages for input parameter panics

### DIFF
--- a/src/annotation_process.rs
+++ b/src/annotation_process.rs
@@ -327,7 +327,7 @@ impl AnnotationProcess {
         // panic! if query.id already in results, this means the input SSSR files were not sorted
         // by query identifiers (`qacc` in Blast terminology):
         if self.human_readable_descriptions.contains_key(&qacc) {
-            panic!( "Found an unexpected occurrence of query {:?} while parsing input files. Make sure your sequence similarity search result tables are sorted by query identifiers, i.e. `qacc` in Blast terminology. Use GNU sort, e.g. `sort -k <qacc-col-no> <your-blast-out-table>`.", &qacc);
+            panic!( "\n\nFound an unexpected occurrence of query {:?} while parsing input files. Make sure your sequence similarity search result tables are sorted by query identifiers, i.e. `qacc` in Blast terminology. Use GNU sort, e.g. `sort -k <qacc-col-no> <your-blast-out-table>`.\n\n", &qacc);
         }
         if !self.queries.contains_key(&qacc) {
             self.queries.insert(qacc.clone(), query);
@@ -361,7 +361,7 @@ impl AnnotationProcess {
             if self.query_id_to_seq_family_id_index.contains_key(query_id) {
                 let other_family_id = self.query_id_to_seq_family_id_index.get(query_id).unwrap();
                 if *other_family_id != seq_family_id {
-                    panic!("Biological sequence {:?} already set as member of family {:?}. But found {:?} again declared as member of another family {:?}.\nMake sure each biological sequence appears in one and only one family to avoid this problem.", query_id, other_family_id, query_id, seq_family_id);
+                    panic!("\n\nBiological sequence {:?} already set as member of family {:?}. But found {:?} again declared as member of another family {:?}.\nMake sure each biological sequence appears in one and only one family to avoid this problem.\n\n", query_id, other_family_id, query_id, seq_family_id);
                 }
             }
             self.query_id_to_seq_family_id_index
@@ -690,7 +690,7 @@ impl AnnotationProcess {
         // --header
         if !self.ssst_columns.is_empty() && self.ssst_columns.len() != n_ssst {
             let n_ssst_cols = self.ssst_columns.len();
-            panic!("Cannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but only {} column mappings. Please provide either no column mappings, causing the default to be used for all SSSTs, or provide one --field_separator (-e) argument for each of your input SSSTs. See --help for more details.", n_ssst_cols, n_ssst);
+            panic!("\n\nCannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but only {} column mappings. Please provide either no column mappings, causing the default to be used for all SSSTs, or provide one --field_separator (-e) argument for each of your input SSSTs. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L172-L182\n\n", n_ssst_cols, n_ssst);
         }
         if !self.ssst_columns.is_empty() {
             let required_cols = vec!["qacc", "sacc", "stitle"];
@@ -698,7 +698,7 @@ impl AnnotationProcess {
                 for col_i in &required_cols {
                     if !ssst_cols_i.contains_key(&col_i.to_string()) {
                         panic!(
-                            "Cannot run Annotation-Process, because --header (-e) argument number {} does not contain required column {:?}!",
+                            "\n\nCannot run Annotation-Process, because --header (-e) argument number {} does not contain required column {:?}!\n\n",
                             i + 1, col_i
                         );
                     }
@@ -709,13 +709,13 @@ impl AnnotationProcess {
         // --blacklist-regexs
         if !self.ssst_blacklist_regexs.is_empty() && self.ssst_blacklist_regexs.len() != n_ssst {
             let n_blacklist_regexs = self.ssst_blacklist_regexs.len();
-            panic!("Cannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --blacklist-regexs (-b). Please provide either no --blacklist-regexs, causing the default to be used for all SSSTs, or provide one --blacklist-regexs (-b) argument for each of your input SSSTs. See --help for more details.", n_ssst, n_blacklist_regexs);
+            panic!("\n\nCannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --blacklist-regexs (-b). Please provide either no --blacklist-regexs, causing the default to be used for all SSSTs, or provide one --blacklist-regexs (-b) argument for each of your input SSSTs. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L145-L154\n\n", n_ssst, n_blacklist_regexs);
         }
 
         // --filter-regexs
         if !self.ssst_filter_regexs.is_empty() && self.ssst_filter_regexs.len() != n_ssst {
             let n_ssst_filter_regexs = self.ssst_filter_regexs.len();
-            panic!("Cannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --filter-regexs (-l). Please provide either no --filter-regexs, causing the default to be used for all SSSTs, or provide one --filter-regexs (-l) argument for each of your input SSSTs. See --help for more details.", n_ssst, n_ssst_filter_regexs);
+            panic!("\n\nCannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --filter-regexs (-l). Please provide either no --filter-regexs, causing the default to be used for all SSSTs, or provide one --filter-regexs (-l) argument for each of your input SSSTs. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L201-L213\n\n", n_ssst, n_ssst_filter_regexs);
         }
 
         // --capture-replace-pairs
@@ -723,25 +723,25 @@ impl AnnotationProcess {
             && self.ssst_capture_replace_pairs.len() != n_ssst
         {
             let n_ssst_capture_replace_pairs = self.ssst_capture_replace_pairs.len();
-            panic!("Cannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --capture-replace-pairs (-c). Please provide either no --capture-replace-pairs, causing the default to be used for all SSSTs, or provide one --capture-replace-pairs (-c) argument for each of your input SSSTs. See --help for more details.", n_ssst, n_ssst_capture_replace_pairs);
+            panic!("\n\nCannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} --capture-replace-pairs (-c). Please provide either no --capture-replace-pairs, causing the default to be used for all SSSTs, or provide one --capture-replace-pairs (-c) argument for each of your input SSSTs. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L156-L170\n\n", n_ssst, n_ssst_capture_replace_pairs);
         }
 
         // --field-separator
         if !self.ssst_field_separators.is_empty() && self.ssst_field_separators.len() != n_ssst {
             let n_ssst_field_seps = self.ssst_field_separators.len();
-            panic!("Cannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} field-separators. Please provide either no field-separators, causing the default to be used for all SSSTs, or provide one --field-separator (-p) argument for each of your input SSSTs. See --help for more details.", n_ssst, n_ssst_field_seps);
+            panic!("\n\nCannot run Annotation-Process, because got {} sequence similarity search result tables (SSSTs), but {} field-separators. Please provide either no field-separators, causing the default to be used for all SSSTs, or provide one --field-separator (-p) argument for each of your input SSSTs. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L224-L229\n\n", n_ssst, n_ssst_field_seps);
         }
 
         // --n-threads
         if self.n_threads < 2 {
-            panic!("Cannot run Annotation-Process, because option '--n-threads' ('-n') must at least be minimum of two (2)!");
+            panic!("\n\nCannot run Annotation-Process, because option '--n-threads' ('-n') must at least be minimum of two (2)!\n\n");
         }
 
         // --center-inverse-word-information-content-at-quantile
         if self.center_iic_at_quantile != 50.0
             && (self.center_iic_at_quantile < 0.0 || self.center_iic_at_quantile > 1.0)
         {
-            panic!("Cannot run Annotation-Process, because option '--center-inverse-word-information-content-at-quantile' ('-q') is not a real value between zero and one (both inclusive) or literal 50 (indicating centering at the mean and not a quantile). Please provide a correct value. See --help for more details.");
+            panic!("\n\nCannot run Annotation-Process, because option '--center-inverse-word-information-content-at-quantile' ('-q') is not a real value between zero and one (both inclusive) or literal 50 (indicating centering at the mean and not a quantile). Please provide a correct value. See --help or the following link for more details.\n\nhttps://github.com/usadellab/prot-scriber/blob/880d32bab31ab5d0b2a3708a9faec8f37b53be9b/README.md?plain=1#L231-L235\n\n");
         }
     }
 }

--- a/src/generate_hrd_associated_funcs.rs
+++ b/src/generate_hrd_associated_funcs.rs
@@ -300,7 +300,7 @@ pub fn centered_inverse_information_content(
 pub fn word_scores_quantile(values: &Vec<(String, f64)>, tau: f64) -> f64 {
     if tau != 50.0 && (tau < 0.0 || tau > 1.0) {
         panic!(
-            "Cannot compute quantile {:?} because it is not a valid value between zero and one (inclusive) or a literal 50.0.",
+            "\n\nCannot compute quantile {:?} because it is not a valid value between zero and one (inclusive) or a literal 50.0.\n\n",
             &tau
         );
     }

--- a/src/model_funcs.rs
+++ b/src/model_funcs.rs
@@ -79,7 +79,7 @@ pub fn parse_regex_file(path: &str) -> Vec<Regex> {
             Ok(regex) => {
                 parsed_regexs.push(regex);
             }
-            Err(e) => panic!("{:?} in file {:?} line <{:?}>. Could not parse the line into a Rust regular expression", e, file_path, i),
+            Err(e) => panic!("\n\n{:?} in file {:?} line <{:?}>. Could not parse the line into a Rust regular expression\n\n", e, file_path, i),
         }
     }
     parsed_regexs
@@ -124,7 +124,7 @@ pub fn parse_regex_replace_tuple_file(path: &str) -> Vec<(Regex, String)> {
     // If we have an odd number of lines, the file is malformed:
     if n_lines & 1 == 1 {
         panic!(
-            "--capture-replace-pairs (-c) argument file {:?} has {:?} lines. But to construct pairs we need an even number of lines. See --help (-h) for more details.",
+            "\n\n--capture-replace-pairs (-c) argument file {:?} has {:?} lines. But to construct pairs we need an even number of lines. See --help (-h) for more details.\n\n",
             path, n_lines
         );
     }

--- a/src/seq_family_reader.rs
+++ b/src/seq_family_reader.rs
@@ -27,7 +27,7 @@ pub fn parse_seq_families_file(path: &str, annotation_process: &mut AnnotationPr
             Ok((seq_fam_name, seq_fam_instance)) => {
                 annotation_process.insert_seq_family(seq_fam_name, seq_fam_instance)
             }
-            Err(e) => panic!("{:?} in file {:?} line <{:?}>. The expected format is \"<family-name>TABgene1,gene2,gene3,...\"", e, file_path, i),
+            Err(e) => panic!("\n\n{:?} in file {:?} line <{:?}>. The expected format is \"<family-name>TABgene1,gene2,gene3,...\"\n\n", e, file_path, i),
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements improvement of the panic error messages thrown when providing malformed input arguments to the CLI.

Closes #31 

## Changes

- Add a double newline in front and after the actual error message to make it stand out more: `\n\n<error message>\n\n`
- Add a link to the README manual entry highlighting the input argument that threw the error.