### PR TITLE
Fix two silent query-loss bugs in the annotation process

### DIFF
--- a/src/annotation_process.rs
+++ b/src/annotation_process.rs
@@ -925,6 +925,35 @@ mod tests {
         ap.insert_query(qacc, nq1);
     }
 
+    // Regression test: the "unsorted input" duplicate-detection only works in
+    // `AnnotationProcessMode::SequenceAnnotation`, because it checks
+    // `human_readable_descriptions.contains_key(&qacc)`. In
+    // `AnnotationProcessMode::FamilyAnnotation`, however, `human_readable_descriptions` is keyed
+    // by seq-family-id, not query-id (see `annotate_seq_family`), so the very same qacc
+    // reappearing non-contiguously -- i.e. the input table was not sorted by qacc -- goes
+    // completely undetected: the second, spurious `Query` is silently inserted as an orphan
+    // (since `annotate_seq_family` has already removed the query from `self.queries` and
+    // `query_id_to_seq_family_id_index` once its family got annotated) and its data is lost
+    // without a warning, instead of causing the same loud panic as in sequence-annotation mode.
+    #[test]
+    #[should_panic]
+    fn insert_query_panics_in_case_of_unsorted_blast_table_in_family_mode() {
+        let mut ap = AnnotationProcess::new();
+        ap.seq_sim_search_tables = vec!["blast_out_table.txt".to_string()];
+        let qacc = "Soltu.DM.02G015700.1".to_string();
+        let mut sf1 = SeqFamily::new();
+        sf1.query_ids = vec![qacc.clone()];
+        ap.insert_seq_family("SeqFamily1".to_string(), sf1);
+
+        // First (legitimate) arrival of the query's data completes and annotates the family:
+        ap.insert_query(qacc.clone(), Query::new());
+        assert!(ap.human_readable_descriptions.contains_key("SeqFamily1"));
+
+        // A second, non-contiguous arrival of the very same qacc (as would happen with an
+        // unsorted input file) must panic instead of being silently dropped as an orphan:
+        ap.insert_query(qacc, Query::new());
+    }
+
     #[test]
     fn insert_family_works() {
         let mut ap = AnnotationProcess::new();

--- a/src/annotation_process.rs
+++ b/src/annotation_process.rs
@@ -14,7 +14,7 @@ use super::seq_sim_table_reader::parse_table;
 use num_cpus;
 use rayon::prelude::*;
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
@@ -45,6 +45,12 @@ pub struct AnnotationProcess {
     /// The in memory database of parsed sequence similarity search results in terms of Queries
     /// with their respective Hits.
     pub queries: HashMap<String, Query>,
+    /// The set of query identifiers for which all input SSST files have already contributed their
+    /// data, i.e. for which `process_query_data_complete` has already run. Tracked independently
+    /// of `human_readable_descriptions` to detect unsorted input (see `insert_query`): in
+    /// `AnnotationProcessMode::FamilyAnnotation` `human_readable_descriptions` is keyed by
+    /// seq-family-id, not query-id, so it cannot serve that purpose in that mode.
+    pub completed_query_ids: HashSet<String>,
     /// The in memory database of biological sequence families, i.e. sets of query identifiers, to
     /// be annotated with human readable descriptions. Keys are the families identifier and values
     /// are the SeqFamily instances.
@@ -308,6 +314,7 @@ impl AnnotationProcess {
             ssst_capture_replace_pairs: vec![],
             ssst_field_separators: vec![],
             queries: HashMap::new(),
+            completed_query_ids: HashSet::new(),
             seq_families: HashMap::new(),
             seq_family_id_genes_separator: (*SPLIT_GENE_FAMILY_ID_FROM_GENE_SET).to_string(),
             seq_family_gene_ids_separator: (*SPLIT_GENE_FAMILY_GENES_REGEX).to_string(),
@@ -339,9 +346,12 @@ impl AnnotationProcess {
     ///                    self.queries.
     /// * `query: Query` - A reference to the query to be inserted into the in memory database.
     pub fn insert_query(&mut self, qacc: String, query: Query) {
-        // panic! if query.id already in results, this means the input SSSR files were not sorted
-        // by query identifiers (`qacc` in Blast terminology):
-        if self.human_readable_descriptions.contains_key(&qacc) {
+        // panic! if query.id was already completed, this means the input SSSR files were not
+        // sorted by query identifiers (`qacc` in Blast terminology). Note this must check
+        // `completed_query_ids`, and not e.g. `human_readable_descriptions`: in
+        // `AnnotationProcessMode::FamilyAnnotation` the latter is keyed by seq-family-id, not
+        // query-id, so relying on it silently misses this exact problem in family mode.
+        if self.completed_query_ids.contains(&qacc) {
             panic!( "\n\nFound an unexpected occurrence of query {:?} while parsing input files. Make sure your sequence similarity search result tables are sorted by query identifiers, i.e. `qacc` in Blast terminology. Use GNU sort, e.g. `sort -k <qacc-col-no> <your-blast-out-table>`.\n\n", &qacc);
         }
         if !self.queries.contains_key(&qacc) {
@@ -356,6 +366,7 @@ impl AnnotationProcess {
         // Have all input SSSR files provided data for the argument `query`?
         if stored_query.n_parsed_from_sssr_tables == self.seq_sim_search_tables.len() as u16 {
             let _ = stored_query;
+            self.completed_query_ids.insert(qacc.clone());
             // If yes, then process the parsed data:
             self.process_query_data_complete(qacc);
         }
@@ -918,9 +929,9 @@ mod tests {
         let nq1 = Query::new();
         let qacc = "Soltu.DM.02G015700.1".to_string();
 
-        // Mark nq1 as already processed:
-        ap.human_readable_descriptions
-            .insert(qacc.clone(), "Unknown protein".to_string());
+        // Mark qacc as already completed, simulating that all input SSST files already fully
+        // reported this query once before, as happens after a legitimate first completion:
+        ap.completed_query_ids.insert(qacc.clone());
         // Should panic:
         ap.insert_query(qacc, nq1);
     }

--- a/src/seq_sim_table_reader.rs
+++ b/src/seq_sim_table_reader.rs
@@ -85,6 +85,62 @@ pub fn parse_table(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::default::{BLACKLIST_STITLE_REGEXS, FILTER_REGEXS};
+    use std::collections::HashMap;
+    use std::sync::mpsc;
+
+    // Regression test for a bug where a query is silently dropped -- never sent to the receiver
+    // at all -- if (a) every one of its Hit descriptions matches a blacklist regex (e.g.
+    // "hypothetical protein") AND (b) it happens to be the last `qacc` block in the input file.
+    // Every other position in the file is unaffected by (a) alone, because the qacc-change branch
+    // inside the parsing loop always sends the accumulated `curr_query` regardless of whether any
+    // of its hits survived blacklist/filtering; only the trailing send after the loop, for the
+    // very last query block, additionally requires `curr_query.hits` to be non-empty -- which an
+    // all-blacklisted last query never is. The practical impact: such a query does not even show
+    // up as "unknown protein" in the output. It just vanishes, and whether it does so depends
+    // purely on its position in the (correctly sorted) input file, not on its data.
+    #[test]
+    fn parse_table_sends_last_query_even_if_all_its_hits_are_blacklisted() {
+        let path = Path::new("misc")
+            .join("tmp_test_parse_table_last_query_all_blacklisted.txt")
+            .to_str()
+            .unwrap()
+            .to_string();
+        std::fs::write(
+            &path,
+            concat!(
+                "Query1\tHit1\tsome informative kinase domain\n",
+                "Query2\tHit2\thypothetical protein\n"
+            ),
+        )
+        .unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        parse_table(
+            &path,
+            &'\t',
+            &0,
+            &1,
+            &2,
+            &BLACKLIST_STITLE_REGEXS,
+            &FILTER_REGEXS,
+            None,
+            tx,
+        );
+        std::fs::remove_file(&path).unwrap();
+
+        let received: HashMap<String, Query> = rx.into_iter().collect();
+        assert!(received.contains_key("Query1"));
+        // Query2 is the last block in the file and all its hits are blacklisted ("hypothetical
+        // protein"); it must still be reported, with zero surviving hits, not silently dropped:
+        assert!(received.contains_key("Query2"));
+        assert!(received.get("Query2").unwrap().hits.is_empty());
+    }
+}
+
 /// The output is wrapped in a Result to allow matching on errors Returns an Iterator to the Reader
 /// of the lines of the file.
 ///

--- a/src/seq_sim_table_reader.rs
+++ b/src/seq_sim_table_reader.rs
@@ -79,8 +79,14 @@ pub fn parse_table(
         }
     }
 
-    // Send last parsed query:
-    if curr_query.hits.len() > 0 && !last_qacc.is_empty() {
+    // Send last parsed query. Note this must NOT require `curr_query.hits` to be non-empty: the
+    // qacc-change branch above always sends `curr_query` regardless of whether any hits survived
+    // blacklist/filtering, so a query whose hits are all blacklisted (e.g. every Hit is
+    // "hypothetical protein") must be sent here too, or it is silently dropped from the
+    // annotation process entirely whenever it happens to be the last query in the file -- instead
+    // of being registered with zero hits and annotated as "unknown protein", like an otherwise
+    // identical query positioned anywhere else in the (sorted) input file:
+    if !last_qacc.is_empty() {
         transmitter.send((last_qacc, curr_query)).unwrap();
     }
 }


### PR DESCRIPTION
Two bugs that discard input data with no warning. In both, whether a query survives depends on something other than that query's own content.

## 1. The last query in a file vanishes if all its hits are blacklisted

`parse_table` sends the accumulated `curr_query` from two places. The qacc-change branch inside the parsing loop sends unconditionally. The trailing send after the loop additionally required `curr_query.hits` to be non-empty — which an all-blacklisted query never is.

So a query whose every Hit description matches a blacklist regex (e.g. `hypothetical protein`) is registered with zero hits and annotated `unknown protein` anywhere in the file, and disappears completely at the end of it. Not present in the output as `unknown protein`: absent entirely. Its fate is decided by its line number in a correctly sorted input.

Fix: drop the `hits` condition from the trailing send.

## 2. Unsorted-input detection never fires in family mode

`insert_query` detects a query reappearing non-contiguously — the signature of an input table not sorted by `qacc` — via `human_readable_descriptions.contains_key(&qacc)`, and panics with a message telling the user to `sort` their table.

In `AnnotationProcessMode::FamilyAnnotation` that map is keyed by seq-family-id, not query-id (see `annotate_seq_family`), so the check never fires. The second, spurious `Query` is silently inserted as an orphan — `annotate_seq_family` has by then removed the query from `self.queries` and `query_id_to_seq_family_id_index` — and its data is lost. Sequence-annotation mode panics loudly on exactly the same input.

Fix: track completion in a new `AnnotationProcess.completed_query_ids`, which is independent of how `human_readable_descriptions` happens to be keyed, so the check now behaves identically in both modes.

## Tests

Two regression tests, both verified to fail before the fix:

- `parse_table_sends_last_query_even_if_all_its_hits_are_blacklisted`
- `insert_query_panics_in_case_of_unsorted_blast_table_in_family_mode`

`seq_sim_table_reader.rs` had no test module; this adds one.

The pre-existing `insert_query_panics_in_case_of_unsorted_blast_table` primed `human_readable_descriptions` to simulate an already-processed query, and now primes `completed_query_ids` — the field the check actually reads. The behaviour it pins is unchanged.

27 tests pass.

## Note

Independent of #50 (non-reproducible HRD output) and based on the same `master`, so the two can merge in either order. They both touch `src/annotation_process.rs` — #50 adds tests to its test module, this adds a struct field and a test — so a trivial conflict is possible depending on merge order.

No version bump here, since #50 already claims 0.1.7; if both land, that release carries all four fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
